### PR TITLE
Fix dot-notation columns and edit modal for relationship repeaters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+/vendor
+/build
+/dist/coverage
+composer.lock
+.phpunit.result.cache
+.phpunit.cache
+phpunit.xml
+.DS_Store
+Thumbs.db

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require-dev": {
         "orchestra/testbench": "^10.0",
         "pestphp/pest": "^4.0",
-        "pestphp/pest-plugin-livewire": "^3.0"
+        "pestphp/pest-plugin-livewire": "^4.0"
     },
     "autoload": {
         "psr-4": {
@@ -36,5 +36,10 @@
         }
     },
     "minimum-stability": "dev",
-    "prefer-stable": true
+    "prefer-stable": true,
+    "config": {
+        "allow-plugins": {
+            "pestphp/pest-plugin": true
+        }
+    }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+>
+    <testsuites>
+        <testsuite name="Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+    <source>
+        <include>
+            <directory>src</directory>
+        </include>
+    </source>
+</phpunit>

--- a/src/ModalRepeater.php
+++ b/src/ModalRepeater.php
@@ -9,6 +9,7 @@ use Filament\Schemas\Components\Grid;
 use Filament\Support\Enums\Size;
 use Filament\Support\Enums\Width;
 use Filament\Support\Icons\Heroicon;
+use Illuminate\Database\Eloquent\Model;
 
 class ModalRepeater extends Repeater
 {
@@ -97,6 +98,24 @@ class ModalRepeater extends Repeater
         return $this->evaluate($this->modalSchema) ?? [];
     }
 
+    /**
+     * Build the grid wrapping the modal schema. When the repeater is bound to a
+     * relationship, the grid is tied to the related model so nested fields
+     * (e.g. a Select using its own relationship) resolve against that model
+     * instead of the parent form's model.
+     */
+    public function makeModalGrid(): Grid
+    {
+        $grid = Grid::make($this->getModalColumns())
+            ->schema($this->getModalSchema());
+
+        if ($this->hasRelationship()) {
+            $grid->model($this->getRelatedModel());
+        }
+
+        return $grid;
+    }
+
     public function getDefaultView(): string
     {
         return 'modal-repeater::modal-repeater';
@@ -108,8 +127,7 @@ class ModalRepeater extends Repeater
             ->label(fn (self $component) => $component->getAddActionLabel())
             ->color('gray')
             ->schema(fn (self $component) => [
-                Grid::make($component->getModalColumns())
-                    ->schema($component->getModalSchema()),
+                $component->makeModalGrid(),
             ])
             ->modalHeading(fn (self $component) => $component->getAddActionLabel())
             ->modalWidth(fn (self $component) => $component->getModalWidth())
@@ -156,8 +174,7 @@ class ModalRepeater extends Repeater
         $action = Action::make('edit')
             ->label(__('filament-actions::edit.single.label'))
             ->schema(fn (self $component) => [
-                Grid::make($component->getModalColumns())
-                    ->schema($component->getModalSchema()),
+                $component->makeModalGrid(),
             ])
             ->modalHeading(__('filament-actions::edit.single.label'))
             ->modalWidth(fn (self $component) => $component->getModalWidth())
@@ -201,13 +218,46 @@ class ModalRepeater extends Repeater
     {
         $items = $this->getRawState();
         $itemState = $items[$itemKey] ?? [];
+
+        $record = $this->resolveItemRecord($itemKey, $itemState);
+
         $values = [];
 
         foreach ($this->getDisplayColumns() as $column) {
-            $rawValue = $itemState[$column->getName()] ?? null;
-            $values[$column->getName()] = $column->resolveValue($rawValue);
+            $name = $column->getName();
+
+            // When the item maps to an Eloquent record, resolve against it so
+            // dot-notation columns (e.g. "competency.name") traverse relations.
+            // Otherwise read straight from the array state, still honouring dots.
+            $rawValue = $record
+                ? data_get($record, $name)
+                : data_get($itemState, $name);
+
+            $values[$name] = $column->resolveValue($rawValue);
         }
 
         return $values;
+    }
+
+    /**
+     * Resolve the Eloquent record an item maps to, for relationship repeaters.
+     * Returns null for plain array repeaters, whose values live in the state.
+     */
+    protected function resolveItemRecord(string $itemKey, array $itemState): ?Model
+    {
+        if (! $this->hasRelationship()) {
+            return null;
+        }
+
+        $existingRecord = $this->getCachedExistingRecords()[$itemKey] ?? null;
+
+        // Clone the persisted record (keeping any eager-loaded relations) or
+        // build a fresh one for new items, then overlay the current state so
+        // relationship columns reflect unsaved edits made in the modal.
+        $relatedModel = $this->getRelatedModel();
+
+        $record = $existingRecord ? clone $existingRecord : new $relatedModel;
+
+        return $record->forceFill($itemState);
     }
 }

--- a/tests/PlainRepeaterTest.php
+++ b/tests/PlainRepeaterTest.php
@@ -1,0 +1,92 @@
+<?php
+
+use Filament\Actions\Concerns\InteractsWithActions;
+use Filament\Actions\Contracts\HasActions;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Concerns\InteractsWithForms;
+use Filament\Forms\Contracts\HasForms;
+use Filament\Schemas\Schema;
+use Illuminate\Support\MessageBag;
+use Livewire\Component as LivewireComponent;
+use Livewire\Livewire;
+use YousefAman\ModalRepeater\Column;
+use YousefAman\ModalRepeater\ModalRepeater;
+
+/*
+ * Ensures the relationship-aware changes do not regress plain (array-state)
+ * repeaters that are not bound to an Eloquent relationship.
+ */
+
+class PlainItemsForm extends LivewireComponent implements HasActions, HasForms
+{
+    use InteractsWithActions;
+    use InteractsWithForms;
+
+    public ?array $data = [];
+
+    public function mount(): void
+    {
+        $this->form->fill([
+            'items' => [
+                ['name' => 'Widget', 'price' => 10],
+            ],
+        ]);
+    }
+
+    public function getErrorBag()
+    {
+        return new MessageBag;
+    }
+
+    public function form(Schema $schema): Schema
+    {
+        return $schema
+            ->statePath('data')
+            ->components([
+                ModalRepeater::make('items')
+                    ->tableColumns([
+                        Column::make('name')->label('Name'),
+                        Column::make('price')->money('USD'),
+                    ])
+                    ->schema([
+                        TextInput::make('name')->required(),
+                        TextInput::make('price')->numeric()->required(),
+                    ]),
+            ]);
+    }
+
+    public function render(): string
+    {
+        return <<<'BLADE'
+            <div>{{ $this->form }}</div>
+        BLADE;
+    }
+}
+
+function bootPlainRepeater(): ModalRepeater
+{
+    $form = Livewire::test(PlainItemsForm::class)
+        ->instance()
+        ->getSchema('form');
+
+    return collect($form->getFlatComponents())
+        ->first(fn ($component) => $component instanceof ModalRepeater);
+}
+
+it('still resolves plain array column values for display', function () {
+    $repeater = bootPlainRepeater();
+
+    $itemKey = array_key_first($repeater->getRawState());
+
+    $values = $repeater->getItemDisplayValues($itemKey);
+
+    expect($values['name'])->toBe('Widget')
+        ->and($values['price'])->toBe('10.00 USD');
+});
+
+it('opens the edit modal for a plain array item', function () {
+    Livewire::test(PlainItemsForm::class)
+        ->mountFormComponentAction('items', 'edit', ['item' => '0'])
+        ->assertFormComponentActionMounted('items', 'edit')
+        ->assertHasNoFormComponentActionErrors();
+});

--- a/tests/RelationshipColumnTest.php
+++ b/tests/RelationshipColumnTest.php
@@ -1,0 +1,174 @@
+<?php
+
+use Filament\Actions\Concerns\InteractsWithActions;
+use Filament\Actions\Contracts\HasActions;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Concerns\InteractsWithForms;
+use Filament\Forms\Contracts\HasForms;
+use Filament\Schemas\Schema;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Facades\Schema as DbSchema;
+use Illuminate\Support\MessageBag;
+use Livewire\Component as LivewireComponent;
+use Livewire\Livewire;
+use YousefAman\ModalRepeater\Column;
+use YousefAman\ModalRepeater\ModalRepeater;
+
+/*
+ * Reproduces https://github.com/yousef-aman/filament-modal-repeater/issues/1
+ *
+ * A ModalRepeater bound to a relationship whose related model has its own
+ * relationship (e.g. CompetencyJobProfile->competency). A dot-notation column
+ * `competency.name` should display the related value, and clicking edit should
+ * not throw a LogicException by resolving `competency` against the parent model.
+ */
+
+class Competency extends Model
+{
+    protected $guarded = [];
+
+    public $timestamps = false;
+}
+
+class JobProfile extends Model
+{
+    protected $guarded = [];
+
+    public $timestamps = false;
+
+    public function competencyJobProfiles(): HasMany
+    {
+        return $this->hasMany(CompetencyJobProfile::class);
+    }
+}
+
+class CompetencyJobProfile extends Model
+{
+    protected $guarded = [];
+
+    public $timestamps = false;
+
+    public function competency(): BelongsTo
+    {
+        return $this->belongsTo(Competency::class);
+    }
+}
+
+class JobProfileForm extends LivewireComponent implements HasActions, HasForms
+{
+    use InteractsWithActions;
+    use InteractsWithForms;
+
+    public JobProfile $record;
+
+    public ?array $data = [];
+
+    public function mount(JobProfile $record): void
+    {
+        $this->record = $record;
+
+        $this->form->fill();
+        $this->form->loadStateFromRelationships(shouldHydrate: true);
+    }
+
+    // Livewire v4's data store is not persisted in headless tests, so the
+    // default error bag resolves to null during render. Return a real one.
+    public function getErrorBag()
+    {
+        return new MessageBag;
+    }
+
+    public function form(Schema $schema): Schema
+    {
+        return $schema
+            ->statePath('data')
+            ->model($this->record)
+            ->components([
+                ModalRepeater::make('competencyJobProfiles')
+                    ->relationship()
+                    ->tableColumns([
+                        Column::make('competency.name')->label('Competency'),
+                    ])
+                    ->schema([
+                        Select::make('competency_id')
+                            ->relationship('competency', 'name')
+                            ->required(),
+                    ]),
+            ]);
+    }
+
+    public function render(): string
+    {
+        return <<<'BLADE'
+            <div>{{ $this->form }}</div>
+        BLADE;
+    }
+}
+
+beforeEach(function () {
+    foreach (['competencies', 'job_profiles', 'competency_job_profiles'] as $table) {
+        DbSchema::dropIfExists($table);
+    }
+
+    DbSchema::create('competencies', function ($table) {
+        $table->id();
+        $table->string('name');
+    });
+
+    DbSchema::create('job_profiles', function ($table) {
+        $table->id();
+        $table->string('title');
+    });
+
+    DbSchema::create('competency_job_profiles', function ($table) {
+        $table->id();
+        $table->foreignId('job_profile_id');
+        $table->foreignId('competency_id');
+    });
+
+    $this->php = Competency::create(['name' => 'PHP']);
+    $this->laravel = Competency::create(['name' => 'Laravel']);
+
+    $this->jobProfile = JobProfile::create(['title' => 'Backend Developer']);
+    $this->jobProfile->competencyJobProfiles()->create(['competency_id' => $this->php->id]);
+    $this->jobProfile->competencyJobProfiles()->create(['competency_id' => $this->laravel->id]);
+});
+
+function bootRelationshipRepeater(JobProfile $record): ModalRepeater
+{
+    $form = Livewire::test(JobProfileForm::class, ['record' => $record])
+        ->instance()
+        ->getSchema('form');
+
+    $repeater = collect($form->getFlatComponents())
+        ->first(fn ($component) => $component instanceof ModalRepeater);
+
+    $repeater->fillFromRelationship();
+
+    return $repeater;
+}
+
+it('resolves dot-notation relationship column values for display', function () {
+    $repeater = bootRelationshipRepeater($this->jobProfile);
+
+    expect($repeater->getItemDisplayValues('record-1')['competency.name'])->toBe('PHP')
+        ->and($repeater->getItemDisplayValues('record-2')['competency.name'])->toBe('Laravel');
+});
+
+it('opens the edit modal for a pivot relationship item without a LogicException', function () {
+    // Mounting builds the modal schema, where the relationship Select resolves
+    // its relationship — the exact point that threw before the fix.
+    Livewire::test(JobProfileForm::class, ['record' => $this->jobProfile])
+        ->mountFormComponentAction('competencyJobProfiles', 'edit', ['item' => 'record-1'])
+        ->assertFormComponentActionMounted('competencyJobProfiles', 'edit')
+        ->assertHasNoFormComponentActionErrors();
+});
+
+it('opens the add modal for a relationship without a LogicException', function () {
+    Livewire::test(JobProfileForm::class, ['record' => $this->jobProfile])
+        ->mountFormComponentAction('competencyJobProfiles', 'add')
+        ->assertFormComponentActionMounted('competencyJobProfiles', 'add')
+        ->assertHasNoFormComponentActionErrors();
+});

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,23 +2,53 @@
 
 namespace YousefAman\ModalRepeater\Tests;
 
+use BladeUI\Heroicons\BladeHeroiconsServiceProvider;
+use BladeUI\Icons\BladeIconsServiceProvider;
+use Filament\Actions\ActionsServiceProvider;
 use Filament\FilamentServiceProvider;
 use Filament\Forms\FormsServiceProvider;
+use Filament\Schemas\SchemasServiceProvider;
 use Filament\Support\SupportServiceProvider;
+use Illuminate\Support\MessageBag;
+use Illuminate\Support\ViewErrorBag;
 use Livewire\LivewireServiceProvider;
 use Orchestra\Testbench\TestCase as BaseTestCase;
 use YousefAman\ModalRepeater\ModalRepeaterServiceProvider;
 
 abstract class TestCase extends BaseTestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // The session-backed error bag is normally shared by middleware; bare
+        // Livewire component tests render without it, so share an empty one.
+        view()->share('errors', (new ViewErrorBag)->put('default', new MessageBag));
+    }
+
     protected function getPackageProviders($app): array
     {
         return [
             LivewireServiceProvider::class,
+            BladeIconsServiceProvider::class,
+            BladeHeroiconsServiceProvider::class,
             SupportServiceProvider::class,
+            SchemasServiceProvider::class,
+            ActionsServiceProvider::class,
             FilamentServiceProvider::class,
             FormsServiceProvider::class,
             ModalRepeaterServiceProvider::class,
         ];
+    }
+
+    protected function defineEnvironment($app): void
+    {
+        $app['config']->set('app.key', 'base64:'.base64_encode(str_repeat('a', 32)));
+        $app['config']->set('database.default', 'testing');
+        $app['config']->set('database.connections.testing', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
     }
 }


### PR DESCRIPTION
A ModalRepeater bound to a relationship (e.g. `relationship('competencyJobProfiles')`) resolved dot-notation columns and the modal schema against the parent form's model instead of the related model. This caused two bugs reported in #1:

- A column like `Column::make('competency.name')` showed nothing, because the value was read from the item's flat array state (which only holds the related record's scalar attributes), never traversing the `competency` relation.
- Opening the edit/add modal threw `LogicException: The relationship [competency] does not exist on the model [JobProfile]`, because a relationship field in the modal (e.g. a Select using `->relationship('competency')`) resolved against the parent model the action inherited.

Fixes:

- `makeModalGrid()` wraps the modal schema in a grid bound to the related model (via `getRelatedModel()`) when the repeater uses a relationship, so nested relationship fields resolve correctly. Used by both the add and edit actions.
- `getItemDisplayValues()` now resolves column values against the related Eloquent record (through `resolveItemRecord()`) using `data_get()`, so dot-notation traverses relations and reflects unsaved edits. Plain array repeaters are unaffected (guarded by `hasRelationship()`).

Test infrastructure required to cover this:

- Add a phpunit config and an in-memory SQLite + Filament service-provider setup in the test case.
- Fix the `pest-plugin-livewire` constraint (`^3.0` was incompatible with `pest ^4.0`).
- Add a `.gitignore` (vendor/, composer.lock, phpunit caches).

Adds regression tests for both the relationship and plain-array repeaters.

Closes #1 